### PR TITLE
fix: Docker compose volume to absolute

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,5 +5,5 @@ services:
     build: .
     volumes:
       - .:/app
-      - app/node_modules
+      - /app/node_modules
     command: yarn dev


### PR DESCRIPTION
I was getting the error below:
```bash
Error response from daemon: invalid mount config for type "volume": invalid mount path: 'app/node_modules' mount path must be absolute
```